### PR TITLE
Add a Set<T> method to PropertyChangedBase

### DIFF
--- a/src/TinyLittleMvvm.Demo/ViewModels/MainViewModel.cs
+++ b/src/TinyLittleMvvm.Demo/ViewModels/MainViewModel.cs
@@ -49,12 +49,7 @@ namespace TinyLittleMvvm.Demo.ViewModels {
 
         public string Title {
             get { return _title; }
-            set {
-                if (_title != value) {
-                    _title = value;
-                    NotifyOfPropertyChange(() => Title);
-                }
-            }
+            set { Set(ref _title, value); }
         }
 
         public ICommand ShowSampleDialogCommand { get; }

--- a/src/TinyLittleMvvm.Demo/ViewModels/SampleDialogViewModel.cs
+++ b/src/TinyLittleMvvm.Demo/ViewModels/SampleDialogViewModel.cs
@@ -11,15 +11,14 @@ namespace TinyLittleMvvm.Demo.ViewModels {
             _text = String.Empty;
 
             AddValidationRule(() => Text, text => !String.IsNullOrEmpty(text), "Text must not be empty");
+            ValidateAllRules();
         }
 
         public string Text {
             get { return _text; }
             set {
-                if (_text != value) {
-                    _text = value;
+                if (Set(ref _text, value)) {
                     ValidateAllRules();
-                    NotifyOfPropertyChange(() => Text);
                 }
             }
         }

--- a/src/TinyLittleMvvm.Demo/ViewModels/SampleSubViewModel.cs
+++ b/src/TinyLittleMvvm.Demo/ViewModels/SampleSubViewModel.cs
@@ -4,12 +4,7 @@
 
         public string Text {
             get { return _text; }
-            set {
-                if (_text != value) {
-                    _text = value;
-                    NotifyOfPropertyChange(() => Text);
-                }
-            }
+            set { Set(ref _text, value); }
         }
     }
 }

--- a/src/TinyLittleMvvm/PropertyChangedBase.cs
+++ b/src/TinyLittleMvvm/PropertyChangedBase.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
 namespace TinyLittleMvvm {
@@ -12,6 +14,26 @@ namespace TinyLittleMvvm {
         /// Occurs when a property value changes.
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Set fully implements a Setter for a read-write property,
+        /// using CallerMemberName to raise the notification
+        /// and the ref to the backing field to set the property.
+        /// </summary>
+        /// <typeparam name="T">The type of the return value.</typeparam>
+        /// <param name="backingField">A Reference to the backing field for this property.</param>
+        /// <param name="newValue">The new value.</param>
+        /// <param name="propertyName">The name of the property, usually automatically provided through the CallerMemberName attribute.</param>
+        /// <returns>True if the PropertyChanged event was raised, false otherwise.</returns> 
+        public bool Set<T>(ref T backingField, T newValue, [CallerMemberName] string propertyName = null) {
+            if (EqualityComparer<T>.Default.Equals(backingField, newValue)) {
+                return false;
+            }
+
+            backingField = newValue;
+            NotifyOfPropertyChange(propertyName);
+            return true;
+        }
 
         /// <summary>
         /// Notifies clients that all properties may have changed.
@@ -28,7 +50,7 @@ namespace TinyLittleMvvm {
         /// Raises the <see cref="PropertyChanged"/> event.
         /// </summary>
         /// <param name="propertyName">The name of the changed property.</param>
-        protected virtual void NotifyOfPropertyChange(string propertyName = null) {
+        protected virtual void NotifyOfPropertyChange([CallerMemberName] string propertyName = null) {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 


### PR DESCRIPTION
This PR does

-  Add a Set<T> method which fully implements a Setter for a read-write property, using `CallerMemberName` to raise the notification and the ref to the backing field to set the property.
- Use the new Set<T> method at some property setters

I like the idea of such method (like in other Mvvm libs), cause it's in most cases a one liner...

**Instead**

```csharp
private string _text;

public string Text {
    get { return _text; }
    set {
        if (_text != value) {
            _text = value;
            NotifyOfPropertyChange(() => Text);
        }
    }
}
```

**Now (we can do)**

```csharp
private string _text;

public string Text {
    get { return _text; }
    set { Set(ref _text, value); }
}
```

or

```csharp
public string Text {
    get { return _text; }
    set {
        if (Set(ref _text, value)) {
            ValidateAllRules();
        }
    }
}
```