### PR TITLE
Add support for .net Framework 4.8 and .net 5

### DIFF
--- a/src/TinyLittleMvvm.Demo/TinyLittleMvvm.Demo.csproj
+++ b/src/TinyLittleMvvm.Demo/TinyLittleMvvm.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <OutputType>winexe</OutputType>
     <UseWPF>true</UseWPF>
     <DebugType>Full</DebugType>

--- a/src/TinyLittleMvvm/TinyLittleMvvm.csproj
+++ b/src/TinyLittleMvvm/TinyLittleMvvm.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
 
     <PackageProjectUrl>https://github.com/thoemmi/TinyLittleMvvm</PackageProjectUrl>
     <PackageTags>MVVM;MahApps Metro;MahApps.Metro;WPF</PackageTags>
     <Description>A small opinionated MVVM library</Description>
-    
+
     <UseWPF>true</UseWPF>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -24,13 +24,13 @@
 
   <!-- NuGet packages -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="GitVersionTask" Version="5.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MahApps.Metro" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="MahApps.Metro" Version="2.3.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
update all packages to latest 

add support for .net Framework 4.8 and .net 5 next to .net Framework 4.7.2 and .net core 3.1 for the main project

and replace .net core 3.1 with .net Framework 4.8 and .net 5 for the demo app