### PR TITLE
adds source generator for INotifyPropertyChanged

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           cd src
           dotnet pack TinyLittleMvvm/TinyLittleMvvm.csproj --configuration Release --no-build --output .
+          dotnet pack TinyLittleMvvm.Analyzers/TinyLittleMvvm.Analyzers.csproj --configuration Release --no-build --output .
           dotnet pack TinyLittleMvvm.MahAppsMetro/TinyLittleMvvm.MahAppsMetro.csproj --configuration Release --no-build --output .
           dotnet pack Templates\templatepack.csproj --configuration Release --no-build --output .
   

--- a/src/TinyLittleMvvm.Analyzers/NotifyPropertyChangedGenerator.cs
+++ b/src/TinyLittleMvvm.Analyzers/NotifyPropertyChangedGenerator.cs
@@ -1,0 +1,177 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace TinyLittleMvvm.Analyzers {
+    [Generator]
+    public class NotifyPropertyChangedGenerator : ISourceGenerator {
+        private const string attributeText = @"
+using System;
+namespace TinyLittleMvvm
+{
+    [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    [System.Diagnostics.Conditional(""AutoNotifyGenerator_DEBUG"")]
+    sealed class AutoNotifyAttribute : Attribute
+    {
+        public AutoNotifyAttribute()
+        {
+        }
+        public string? PropertyName { get; set; }
+    }
+}
+";
+
+        public void Initialize(GeneratorInitializationContext context)
+        {
+            // Register the attribute source
+            context.RegisterForPostInitialization(initializationContext => initializationContext.AddSource("AutoNotifyAttribute", attributeText));
+
+            // Register a syntax receiver that will be created for each generation pass
+            context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
+        }
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            // retrieve the populated receiver 
+            if (context.SyntaxContextReceiver is not SyntaxReceiver receiver)
+                return;
+
+            // get the added attribute, and INotifyPropertyChanged
+            var attributeSymbol = context.Compilation.GetTypeByMetadataName("TinyLittleMvvm.AutoNotifyAttribute")!;
+            var notifySymbol = context.Compilation.GetTypeByMetadataName("System.ComponentModel.INotifyPropertyChanged")!;
+
+            // group the fields by class, and generate the source
+            foreach (var group in receiver.Fields.GroupBy(f => f.ContainingType, SymbolEqualityComparer.Default))
+            {
+                if (group.Key is INamedTypeSymbol namedTypeSymbol) {
+                    var classSource = ProcessClass(namedTypeSymbol, group, attributeSymbol, notifySymbol, context);
+                    if (classSource != null)
+                        context.AddSource($"{group.Key.Name}_autoNotify.cs", SourceText.From(classSource, Encoding.UTF8));
+                }
+            }
+        }
+
+        private string? ProcessClass(INamedTypeSymbol classSymbol, IEnumerable<IFieldSymbol> fields, ISymbol attributeSymbol, ISymbol notifySymbol, GeneratorExecutionContext context)
+        {
+            if (!classSymbol.ContainingSymbol.Equals(classSymbol.ContainingNamespace, SymbolEqualityComparer.Default))
+            {
+                return null; //TODO: issue a diagnostic that it must be top level
+            }
+
+            var namespaceName = classSymbol.ContainingNamespace.ToDisplayString();
+
+            // begin building the generated source
+            var source = new StringBuilder($@"
+namespace {namespaceName}
+{{
+    public partial class {classSymbol.Name} : {notifySymbol.ToDisplayString()}
+    {{
+");
+
+            // if the class doesn't implement INotifyPropertyChanged already, add it
+            if (!classSymbol.AllInterfaces.Contains(notifySymbol, SymbolEqualityComparer.Default))
+            {
+                source.Append("public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;");
+            }
+
+            // create properties for each field 
+            foreach (var fieldSymbol in fields)
+            {
+                ProcessField(source, fieldSymbol, attributeSymbol);
+            }
+
+            source.AppendLine(@"    }
+}");
+            return source.ToString();
+        }
+
+        private void ProcessField(StringBuilder source, IFieldSymbol fieldSymbol, ISymbol attributeSymbol)
+        {
+            // get the name and type of the field
+            var fieldName = fieldSymbol.Name;
+            var fieldType = fieldSymbol.Type;
+
+            // get the AutoNotify attribute from the field, and any associated data
+            var attributeData = fieldSymbol.GetAttributes().Single(ad => ad.AttributeClass?.Equals(attributeSymbol, SymbolEqualityComparer.Default) == true);
+            var optionalNameOverride = attributeData.NamedArguments.SingleOrDefault(kvp => kvp.Key == "PropertyName").Value;
+
+            string propertyName = GetPropertyName(fieldName, optionalNameOverride);
+            if (propertyName.Length == 0 || propertyName == fieldName)
+            {
+                //TODO: issue a diagnostic that we can't process this field
+                return;
+            }
+
+            source.Append($@"
+        public {fieldType} {propertyName}
+        {{
+            get 
+            {{
+                return this.{fieldName};
+            }}
+            set
+            {{
+                if (!EqualityComparer<{fieldType}>.Default.Equals(this.{fieldName}, value))
+                {{
+                    var oldValue = this.{fieldName};
+                    this.{fieldName} = value;
+                    this.PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof({propertyName})));
+                    On{propertyName}Changed(oldValue, value);
+                }}
+            }}
+        }}
+        
+        partial void On{propertyName}Changed({fieldType} oldValue, {fieldType} newValue);
+");
+
+        }
+        private static string GetPropertyName(string fieldName, TypedConstant optionalNameOverride)
+        {
+            if (!optionalNameOverride.IsNull)
+            {
+                return optionalNameOverride.Value!.ToString()!;
+            }
+
+            fieldName = fieldName.TrimStart('_');
+            if (fieldName.Length == 0)
+                return string.Empty;
+
+            if (fieldName.Length == 1)
+                return fieldName.ToUpper();
+
+            return fieldName.Substring(0, 1).ToUpper() + fieldName.Substring(1);
+        }
+
+        /// <summary>
+        /// Created on demand before each generation pass
+        /// </summary>
+        private class SyntaxReceiver : ISyntaxContextReceiver
+        {
+            public List<IFieldSymbol> Fields { get; } = new();
+
+            /// <summary>
+            /// Called for every syntax node in the compilation, we can inspect the nodes and save any information useful for generation
+            /// </summary>
+            public void OnVisitSyntaxNode(GeneratorSyntaxContext context)
+            {
+                // any field with at least one attribute is a candidate for property generation
+                if (context.Node is FieldDeclarationSyntax fieldDeclarationSyntax
+                    && fieldDeclarationSyntax.AttributeLists.Count > 0)
+                {
+                    foreach (VariableDeclaratorSyntax variable in fieldDeclarationSyntax.Declaration.Variables)
+                    {
+                        // Get the symbol being declared by the field, and keep it if its annotated
+                        if (context.SemanticModel.GetDeclaredSymbol(variable) is IFieldSymbol fieldSymbol &&
+                            fieldSymbol.GetAttributes().Any(ad => ad.AttributeClass?.ToDisplayString() == "TinyLittleMvvm.AutoNotifyAttribute"))
+                        {
+                            Fields.Add(fieldSymbol);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/TinyLittleMvvm.Analyzers/TinyLittleMvvm.Analyzers.csproj
+++ b/src/TinyLittleMvvm.Analyzers/TinyLittleMvvm.Analyzers.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <Nullable>Enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Package the generator in the analyzer directory of the nuget package -->
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/TinyLittleMvvm.sln
+++ b/src/TinyLittleMvvm.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F15B9A05-2298-464A-8762-762DB004C94F}"
 	ProjectSection(SolutionItems) = preProject
 		..\.github\workflows\build.yaml = ..\.github\workflows\build.yaml
+		..\CHANGELOG.md = ..\CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
 		..\README.md = ..\README.md
 		Templates\templatepack.csproj = Templates\templatepack.csproj
@@ -25,6 +26,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TinyLittleMvvm.MahAppsMetro", "TinyLittleMvvm.MahAppsMetro\TinyLittleMvvm.MahAppsMetro.csproj", "{F5D58A3F-F9B3-4ADF-BF68-1B1C00121662}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateApp.MahAppsMetro", "Templates\TemplateApp.MahAppsMetro\TemplateApp.MahAppsMetro.csproj", "{E560A880-0E39-43AB-86A1-0113EEF5E5FC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TinyLittleMvvm.Analyzers", "TinyLittleMvvm.Analyzers\TinyLittleMvvm.Analyzers.csproj", "{1FE4F861-8964-49DB-9688-CECC3E5A84AF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,6 +55,10 @@ Global
 		{E560A880-0E39-43AB-86A1-0113EEF5E5FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E560A880-0E39-43AB-86A1-0113EEF5E5FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E560A880-0E39-43AB-86A1-0113EEF5E5FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FE4F861-8964-49DB-9688-CECC3E5A84AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FE4F861-8964-49DB-9688-CECC3E5A84AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FE4F861-8964-49DB-9688-CECC3E5A84AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FE4F861-8964-49DB-9688-CECC3E5A84AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The PR adds a new package, **TinyLittleMvvm.Analyzers**.

This package provides a new attribute `TinyLittleMvvm.AutoNotifyAttribute`. When applied to a private field, it will automatically generate a public property, raising the `PropertyChanged` event in the setter. It is based on the source generator sample [AutoNotifyGenerator](https://github.com/dotnet/roslyn-sdk/blob/main/samples/CSharp/SourceGenerators/SourceGeneratorSamples/AutoNotifyGenerator.cs). However, in this implementation the setter first checks if the new value is different (using `EqualityComparer<TField>.Default`). Additionally it will call the partial method `On{PropertyName}Changed(oldValue, newValue)`.

What's missing is an analyzer, which warns when you set the field directly instead of through the property.

When consuming the analyzer package in a WPF application with .NET Core SDK < 5.0.2xx, you have to set the `IncludePackageReferencesDuringMarkupCompilation` property on your csproj:
```xml
<IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
```
See https://github.com/dotnet/wpf/issues/3404 and https://github.com/dotnet/sdk/issues/15395 for details.