### PR TITLE
adds support to analyzer for generic viewmodels extended diagnostics

### DIFF
--- a/src/TinyLittleMvvm.Analyzers.Tests/NotifyPropertyChangedGeneratorTests.cs
+++ b/src/TinyLittleMvvm.Analyzers.Tests/NotifyPropertyChangedGeneratorTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace TinyLittleMvvm.Analyzers.Tests
+{
+    public class NotifyPropertyChangedGeneratorTests
+    {
+        [Fact]
+        public void can_generate_property_in_poco()
+        {
+            // Create the 'input' compilation that the generator will act on
+            Compilation inputCompilation = CreateCompilation(@"
+namespace MyCode
+{
+    public partial class TestClass : TinyLittleMvvm.PropertyChangedBase
+    {
+        [TinyLittleMvvm.AutoNotify]
+        private int _myNumber = 0;
+    }
+}
+");
+
+            // directly create an instance of the generator
+            // (Note: in the compiler this is loaded from an assembly, and created via reflection at runtime)
+            var generator = new NotifyPropertyChangedGenerator();
+
+            // Create the driver that will control the generation, passing in our generator
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+
+            // Run the generation pass
+            // (Note: the generator driver itself is immutable, and all calls return an updated version of the driver that you should use for subsequent calls)
+            driver = driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out var outputCompilation, out var diagnostics);
+
+            // We can now assert things about the resulting compilation:
+            Debug.Assert(diagnostics.IsEmpty); // there were no diagnostics created by the generators
+            Debug.Assert(outputCompilation.SyntaxTrees.Count() == 3); // we have two syntax trees, the original 'user' provided one, and the one added by the generator
+            ImmutableArray<Diagnostic> immutableArray = outputCompilation.GetDiagnostics();
+            //Debug.Assert(immutableArray.IsEmpty); // verify the compilation with the added source has no diagnostics
+
+            // Or we can look at the results directly:
+            GeneratorDriverRunResult runResult = driver.GetRunResult();
+
+            // The runResult contains the combined results of all generators passed to the driver
+            Debug.Assert(runResult.GeneratedTrees.Length == 2);
+            Debug.Assert(runResult.Diagnostics.IsEmpty);
+
+            // Or you can access the individual results on a by-generator basis
+            GeneratorRunResult generatorResult = runResult.Results[0];
+            Debug.Assert(generatorResult.Generator == generator);
+            Debug.Assert(generatorResult.Diagnostics.IsEmpty);
+            Debug.Assert(generatorResult.GeneratedSources.Length == 2);
+            Debug.Assert(generatorResult.Exception is null);
+        }
+
+        [Fact]
+        public void can_generate_property_in_generic_poco()
+        {
+            // Create the 'input' compilation that the generator will act on
+            Compilation inputCompilation = CreateCompilation(@"
+namespace MyCode
+{
+    public partial class TestClass<T> : TinyLittleMvvm.PropertyChangedBase
+    {
+        [TinyLittleMvvm.AutoNotify]
+        private int _myNumber = 0;
+    }
+}
+");
+
+            // directly create an instance of the generator
+            // (Note: in the compiler this is loaded from an assembly, and created via reflection at runtime)
+            var generator = new NotifyPropertyChangedGenerator();
+
+            // Create the driver that will control the generation, passing in our generator
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+
+            // Run the generation pass
+            // (Note: the generator driver itself is immutable, and all calls return an updated version of the driver that you should use for subsequent calls)
+            driver = driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out var outputCompilation, out var diagnostics);
+
+            // We can now assert things about the resulting compilation:
+            Debug.Assert(diagnostics.IsEmpty); // there were no diagnostics created by the generators
+            Debug.Assert(outputCompilation.SyntaxTrees.Count() == 3); // we have two syntax trees, the original 'user' provided one, and the one added by the generator
+            ImmutableArray<Diagnostic> immutableArray = outputCompilation.GetDiagnostics();
+            //Debug.Assert(immutableArray.IsEmpty); // verify the compilation with the added source has no diagnostics
+
+            // Or we can look at the results directly:
+            GeneratorDriverRunResult runResult = driver.GetRunResult();
+
+            // The runResult contains the combined results of all generators passed to the driver
+            Debug.Assert(runResult.GeneratedTrees.Length == 2);
+            Debug.Assert(runResult.Diagnostics.IsEmpty);
+
+            // Or you can access the individual results on a by-generator basis
+            GeneratorRunResult generatorResult = runResult.Results[0];
+            Debug.Assert(generatorResult.Generator == generator);
+            Debug.Assert(generatorResult.Diagnostics.IsEmpty);
+            Debug.Assert(generatorResult.GeneratedSources.Length == 2);
+            Debug.Assert(generatorResult.Exception is null);
+        }
+
+        private static Compilation CreateCompilation(string source)
+            => CSharpCompilation.Create("compilation",
+                new[] { CSharpSyntaxTree.ParseText(source) },
+                new[] {
+                    MetadataReference.CreateFromFile(typeof(Binder).GetTypeInfo().Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(Expression<>).GetTypeInfo().Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(PropertyChangedBase).GetTypeInfo().Assembly.Location),
+                },
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/src/TinyLittleMvvm.Analyzers.Tests/TinyLittleMvvm.Analyzers.Tests.csproj
+++ b/src/TinyLittleMvvm.Analyzers.Tests/TinyLittleMvvm.Analyzers.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0-windows</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TinyLittleMvvm.Analyzers\TinyLittleMvvm.Analyzers.csproj" />
+    <ProjectReference Include="..\TinyLittleMvvm\TinyLittleMvvm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/TinyLittleMvvm.Analyzers/TinyLittleMvvm.Analyzers.csproj
+++ b/src/TinyLittleMvvm.Analyzers/TinyLittleMvvm.Analyzers.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <!-- Package the generator in the analyzer directory of the nuget package -->
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="TinyLittleMvvm.Analyzers.props" Pack="true" PackagePath="build" Visible="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TinyLittleMvvm.Analyzers/TinyLittleMvvm.Analyzers.props
+++ b/src/TinyLittleMvvm.Analyzers/TinyLittleMvvm.Analyzers.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <!--
+      Enable Source Generators for .NET Core 5 WPF applications. Starting with .NET Core 6, this property will be true by default.
+      See https://github.com/dotnet/sdk/issues/15395 for more information
+    -->
+    <IncludePackageReferencesDuringMarkupCompilation Condition="'$(IncludePackageReferencesDuringMarkupCompilation)'==''">true</IncludePackageReferencesDuringMarkupCompilation>
+  </PropertyGroup>
+</Project>

--- a/src/TinyLittleMvvm.sln
+++ b/src/TinyLittleMvvm.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateApp.MahAppsMetro", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TinyLittleMvvm.Analyzers", "TinyLittleMvvm.Analyzers\TinyLittleMvvm.Analyzers.csproj", "{1FE4F861-8964-49DB-9688-CECC3E5A84AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyLittleMvvm.Analyzers.Tests", "TinyLittleMvvm.Analyzers.Tests\TinyLittleMvvm.Analyzers.Tests.csproj", "{5267A9AA-DD04-437A-A4F2-24E5E82A7BF5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{1FE4F861-8964-49DB-9688-CECC3E5A84AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FE4F861-8964-49DB-9688-CECC3E5A84AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FE4F861-8964-49DB-9688-CECC3E5A84AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5267A9AA-DD04-437A-A4F2-24E5E82A7BF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5267A9AA-DD04-437A-A4F2-24E5E82A7BF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5267A9AA-DD04-437A-A4F2-24E5E82A7BF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5267A9AA-DD04-437A-A4F2-24E5E82A7BF5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Enables `AutoNotify` in generic viewmodels:
  ```csharp
  public partial class GenericViewModel<T> : PropertyChangedBase
  {
     [AutoNotify]
     private int _number;
  }
  ```
- Sets MSBuild property `IncludePackageReferencesDuringMarkupCompilation` to `true` to enable source generator in WPF projects.
  See https://github.com/dotnet/sdk/issues/15395 for details